### PR TITLE
Add Dynamic Stock News and Widget Updates Based on User Search Input

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-API_KEY =d0vf12pr01qkepcvrurgd0vf12pr01qkepcvrus0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
   <header>
     <a id="site-logo" href="#">Stock Analysis App</a>
-    <input type="search" placeholder="Search for Stonk" />
+    <input type="search" id="stock-search" placeholder="Search for Stonk" />
     
   </header>
 
@@ -63,7 +63,7 @@
   <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js" async>
   {
   "symbol": "NASDAQ:AAPL",
-  "width": 550,
+  "width": 1500,
   "locale": "en",
   "colorTheme": "light",
   "isTransparent": true

--- a/index.html
+++ b/index.html
@@ -62,32 +62,16 @@
     <section id="advanced-chart"></section>
     </div>
     </div>
-           </div>
+    </div>
 
     <section id="company-profile"></section>
       <!-- TradingView Company Profile Widget END -->
 
-    <section id="fundamental-data"></section>
+    <section id="financial-data"></section>
       <!-- TradingView Financials Widget END -->
     </section>
     <div id="bottom-widgets">
-    <section id="technical-analysis">
-      <!-- TradingView Technical Analysis Widget BEGIN -->
-      <div class="tradingview-widget-container">
-        <div class="tradingview-widget-container__widget"></div>
-        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-technical-analysis.js" async>
-        {
-          "interval": "1h",
-          "width": "100%",
-          "height": "60%",
-          "symbol": "NASDAQ:AAPL",
-          "showIntervalTabs": false,
-          "displayMode": "single",
-          "locale": "en",
-          "colorTheme": "light"
-        }
-        </script>
-      </div>
+    <section id="technical-analysis"></section>
       <!-- TradingView Technical Analysis Widget END -->
     </section>
 

--- a/index.html
+++ b/index.html
@@ -64,23 +64,8 @@
     </div>
            </div>
 
-    <section id="company-profile">
-      <!-- TradingView Company Profile Widget BEGIN -->
-      <div class="tradingview-widget-container">
-        <div class="tradingview-widget-container__widget"></div>
-        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-profile.js" async>
-        {
-          "width": "400",
-          "height": "350",
-          "isTransparent": true,
-          "colorTheme": "light",
-          "symbol": "NASDAQ:AAPL",
-          "locale": "en"
-        }
-        </script>
-      </div>
+    <section id="company-profile"></section>
       <!-- TradingView Company Profile Widget END -->
-    </section>
 
     <section id="fundamental-data">
       <!-- TradingView Financials Widget BEGIN -->

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
   <header>
     <a id="site-logo" href="#">Stock Analysis App</a>
-    <input type="search" id="stock-search" placeholder="Search for Stonk" />
+    <input type="search" id="stock-search" placeholder="Search for Stonk, press Enter" />
     
   </header>
 
@@ -56,22 +56,9 @@
 </section>
 <div id="right-side">
 <!-- End News Section -->
-    <section id="symbol-info">
-      <!-- TradingView Symbol-Info Widget BEGIN -->
-<div class="tradingview-widget-container">
-  <div class="tradingview-widget-container__widget"></div>
-  <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js" async>
-  {
-  "symbol": "NASDAQ:AAPL",
-  "width": 1500,
-  "locale": "en",
-  "colorTheme": "light",
-  "isTransparent": true
-}
-  </script>
-</div>
+<!-- TradingView Symbol-Info Widget BEGIN -->
+    <section id="symbol-info"></section>
 <!-- TradingView Symbol-Info Widget END -->
-    </section>
     <section id="advanced-chart">
       <!-- TradingView Advanced Chart Widget BEGIN -->
       <div class="tradingview-widget-container">
@@ -178,7 +165,7 @@
   </main>
   <footer>
   </footer>
-
+  <script src="config.js"></script>
   <script src="index.js" ></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -59,29 +59,7 @@
 <!-- TradingView Symbol-Info Widget BEGIN -->
     <section id="symbol-info"></section>
 <!-- TradingView Symbol-Info Widget END -->
-    <section id="advanced-chart">
-      <!-- TradingView Advanced Chart Widget BEGIN -->
-      <div class="tradingview-widget-container">
-        <div class="tradingview-widget-container__widget"></div>
-        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js" async>
-        {
-          "width": "980",
-          "height": "100%",
-          "symbol": "NASDAQ:AAPL",
-          "interval": "60",
-          "timezone": "America/New_York",
-          "theme": "light",
-          "style": "1",
-          "locale": "en",
-          "hide_top_toolbar": true,
-          "allow_symbol_change": true,
-          "studies": ["STD;RSI"],
-          "support_host": "https://www.tradingview.com"
-        }
-        </script>
-      </div>
-      <!-- TradingView Advanced Chart Widget END -->
-    </section>
+    <section id="advanced-chart"></section>
     </div>
     </div>
            </div>

--- a/index.html
+++ b/index.html
@@ -67,22 +67,7 @@
     <section id="company-profile"></section>
       <!-- TradingView Company Profile Widget END -->
 
-    <section id="fundamental-data">
-      <!-- TradingView Financials Widget BEGIN -->
-      <div class="tradingview-widget-container">
-        <div class="tradingview-widget-container__widget"></div>
-        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-financials.js" async>
-        {
-          "isTransparent": true,
-          "displayMode": "adaptive",
-          "width": 400,
-          "height": 550,
-          "colorTheme": "light",
-          "symbol": "NASDAQ:AAPL",
-          "locale": "en"
-        }
-        </script>
-      </div>
+    <section id="fundamental-data"></section>
       <!-- TradingView Financials Widget END -->
     </section>
     <div id="bottom-widgets">

--- a/index.html
+++ b/index.html
@@ -63,36 +63,15 @@
     </div>
     </div>
     </div>
-
     <section id="company-profile"></section>
       <!-- TradingView Company Profile Widget END -->
-
     <section id="financial-data"></section>
       <!-- TradingView Financials Widget END -->
-    </section>
     <div id="bottom-widgets">
     <section id="technical-analysis"></section>
       <!-- TradingView Technical Analysis Widget END -->
-    </section>
-
-    <section id="top-stories">
-      <!-- TradingView Top Stories Widget BEGIN -->
-      <div class="tradingview-widget-container">
-        <div class="tradingview-widget-container__widget"></div>
-        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-timeline.js" async>
-        {
-          "feedMode": "all_symbols",
-          "width": "100%,
-          "height": "60%",
-          "colorTheme": "light",
-          "isTransparent": false,
-          "displayMode": "regular",
-          "locale": "en"
-        }
-        </script>
-      </div>
+    <section id="top-stories"></section>
       <!-- TradingView Top Stories Widget END -->
-    </section>
     </div>
   </main>
   <footer>

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const handleTickerChange = (event) => {
   renderAdvancedChart(newTicker);
   renderCompanyProfile(newTicker);
   renderFinancialData(newTicker);
+  renderTechnicalAnalysis(newTicker);
   }
 };
 
@@ -119,7 +120,7 @@ const renderCompanyProfile = (ticker) => {
 renderCompanyProfile("AAPL");
 
 const renderFinancialData = (ticker) => {
-  const container = document.getElementById("fundamental-data");
+  const container = document.getElementById("financial-data");
   container.innerHTML = "";
 
   const script = document.createElement("script");
@@ -137,6 +138,30 @@ const renderFinancialData = (ticker) => {
     locale: "en",
   });
 
-  container.appendChild("script");
+  container.appendChild(script);
 };
 renderFinancialData("AAPL");
+
+const renderTechnicalAnalysis = (ticker) => {
+  const container = document.getElementById("technical-analysis");
+  container.innerHTML = "";
+
+  const script = document.createElement("script");
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-technical-analysis.js";
+  script.type = "text/javascript";
+  script.async = true;
+
+  script.innerHTML = JSON.stringify({
+    interval: "1h",
+    width: "100%",
+    height: "60%",
+    symbol: `NASDAQ:${ticker}`,
+    showIntervalTabs: false,
+    displayMode: "single",
+    locale: "en",
+    colorTheme: "light"
+  });
+
+  container.appendChild(script);
+};
+renderTechnicalAnalysis("AAPL");

--- a/index.js
+++ b/index.js
@@ -1,13 +1,3 @@
-const apiKey = "d0vf12pr01qkepcvrurgd0vf12pr01qkepcvrus0";
-// const ticker = "AAPL";
-// const from = "2025-05-01";
-// const to = "2025-06-03";
-
-// fetch(`https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`)
-//   .then(res => res.json())
-//   .then(data => displayNews(data))
-//   .catch(err => console.error(err));
-
 // Create a news section
 const newsContainer = document.getElementById('news-articles');
 
@@ -29,12 +19,14 @@ const displayNews = (articles) => {
 
 //Grab Ticker from Stock-Search
 const searchInput = document.getElementById("stock-search");
+searchInput.innerHTML = "";
 
 const handleTickerChange = (event) => {
   if (event.key === "Enter") {
   const newTicker = event.target.value.toUpperCase();
   console.log(newTicker);
-  fetchNews(newTicker)
+  fetchNews(newTicker);
+  renderSymbolInfo(newTicker);
   }
 };
 
@@ -43,13 +35,59 @@ searchInput.addEventListener("keydown", handleTickerChange);
 //Create Fetch News Function to fetch when a new stock is enetered
 
 const fetchNews = (ticker) => {
+  console.log("Fetching news for:", ticker);
   const from = "2025-05-01"
   const to = "2025-06-03"
   const url = `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`;
-  console.log(ticker);
+   console.log("URL:", url);
 
   fetch (url) 
   .then(res => res.json())
   .then(data => displayNews(data))
   .catch(err => console.error(err));
 }
+
+//Create inline JS forTradingView WIdgets to dynimically update with ticker change
+
+// <!-- TradingView Widget BEGIN -->
+// <div class="tradingview-widget-container">
+//   <div class="tradingview-widget-container__widget"></div>
+//   <div class="tradingview-widget-copyright"><a href="https://www.tradingview.com/" rel="noopener nofollow" target="_blank"><span class="blue-text">Track all markets on TradingView</span></a></div>
+//   <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js" async>
+//   {
+//   "symbol": "NASDAQ:AAPL",
+//   "width": 550,
+//   "locale": "en",
+//   "colorTheme": "dark",
+//   "isTransparent": false
+// }
+//   </script>
+// </div>
+// <!-- TradingView Widget END -->
+
+const renderSymbolInfo = (ticker) => {
+  const container = document.getElementById("symbol-info");
+  console.log(1);
+  container.innerHTML = "";
+ console.log(2);
+  const script = document.createElement("script");
+   console.log(3);
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js";
+   console.log(4);
+  script.type = "text/javascript"
+   console.log(5);
+  script.async = true;
+ console.log(6);
+
+  script.innerHTML = JSON.stringify({
+    symbol: `NASDAQ:${ticker}`,
+    width: "100%",
+    locale: "en",
+    colorTheme: "light",
+    isTransparent: false,
+  })
+   console.log(7);
+  container.appendChild(script);
+  console.log(8);
+
+};

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const handleTickerChange = (event) => {
   fetchNews(newTicker);
   renderSymbolInfo(newTicker);
   renderAdvancedChart(newTicker);
+  renderCompanyProfile(newTicker);
   }
 };
 
@@ -71,49 +72,48 @@ const renderSymbolInfo = (ticker) => {
 fetchNews("AAPL");
 renderSymbolInfo("AAPL");
 
-    //   <!-- TradingView Advanced Chart Widget BEGIN -->
-    //   <div class="tradingview-widget-container">
-    //     <div class="tradingview-widget-container__widget"></div>
-    //     <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js" async>
-    //     {
-    //       "width": "980",
-    //       "height": "100%",
-    //       "symbol": "NASDAQ:AAPL",
-    //       "interval": "60",
-    //       "timezone": "America/New_York",
-    //       "theme": "light",
-    //       "style": "1",
-    //       "locale": "en",
-    //       "hide_top_toolbar": true,
-    //       "allow_symbol_change": true,
-    //       "studies": ["STD;RSI"],
-    //       "support_host": "https://www.tradingview.com"
-    //     }
-    //     </script>
-    //   </div>
-    //   <!-- TradingView Advanced Chart Widget END -->
-    // </section>
+const renderAdvancedChart = (ticker) => {
+  const container = document.getElementById("advanced-chart");
+  container.innerHTML = "";
 
-    const renderAdvancedChart = (ticker) => {
-      const container = document.getElementById("advanced-chart");
-      container.innerHTML = "";
+  const script = document.createElement("script");
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js";
+  script.type = "text/javascript";
+  script.async = true;
 
-      const script = document.createElement("script");
-      script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js";
-      script.type = "text/javascript";
-      script.async = true;
+  script.innerHTML = JSON.stringify({
+    autosize: true,
+    symbol: `NASDAQ:${ticker}`,
+    interval: "D",
+    timezone: "America/New_York",
+    theme: "light",
+    style: "1",
+    locale: "en",
+    allow_symbol_change: true,
+  });
 
-      script.innerHTML = JSON.stringify({
-        autosize: true,
-        symbol: `NASDAQ:${ticker}`,
-        interval: "D",
-        timezone: "America/New_York",
-        theme: "light",
-        style: "1",
-        locale: "en",
-        allow_symbol_change: true,
-      });
+  container.appendChild(script);
+};
+renderAdvancedChart("AAPL");
 
-      container.appendChild(script);
-    };
-  renderAdvancedChart("AAPL");
+const renderCompanyProfile = (ticker) => {
+  const container = document.getElementById("company-profile");
+  container.innerHTML = "";
+
+  const script = document.createElement("script");
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-symbol-profile.js";
+  script.type = "text/javascript";
+  script.async = true;
+
+  script.innerHTML = JSON.stringify({
+    width: "400",
+    height: "350",
+    isTransparent: true,
+    colorTheme: "light",
+    symbol: `NASDAQ:${ticker}`,
+    locale: "en",
+  });
+
+  container.appendChild(script);
+};
+renderCompanyProfile("AAPL");

--- a/index.js
+++ b/index.js
@@ -25,3 +25,15 @@ const displayNews = (articles) => {
     newsContainer.appendChild(p);
   });
 }
+
+//Grab Ticker from Stock-Search
+const searchInput = document.getElementById("stock-search");
+
+const handleTickerChange = (event) => {
+  if (event.key ==="Enter") {
+  const newTicker = event.target.value.toUpperCase();
+  console.log(newTicker);
+  }
+};
+
+searchInput.addEventListener("keydown", handleTickerChange);

--- a/index.js
+++ b/index.js
@@ -45,39 +45,16 @@ const fetchNews = (ticker) => {
   .then(res => res.json())
   .then(data => displayNews(data))
   .catch(err => console.error(err));
-}
-
-//Create inline JS forTradingView WIdgets to dynimically update with ticker change
-
-// <!-- TradingView Widget BEGIN -->
-// <div class="tradingview-widget-container">
-//   <div class="tradingview-widget-container__widget"></div>
-//   <div class="tradingview-widget-copyright"><a href="https://www.tradingview.com/" rel="noopener nofollow" target="_blank"><span class="blue-text">Track all markets on TradingView</span></a></div>
-//   <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js" async>
-//   {
-//   "symbol": "NASDAQ:AAPL",
-//   "width": 550,
-//   "locale": "en",
-//   "colorTheme": "dark",
-//   "isTransparent": false
-// }
-//   </script>
-// </div>
-// <!-- TradingView Widget END -->
+};
 
 const renderSymbolInfo = (ticker) => {
   const container = document.getElementById("symbol-info");
-  console.log(1);
   container.innerHTML = "";
- console.log(2);
+
   const script = document.createElement("script");
-   console.log(3);
   script.src = "https://s3.tradingview.com/external-embedding/embed-widget-symbol-info.js";
-   console.log(4);
   script.type = "text/javascript"
-   console.log(5);
   script.async = true;
- console.log(6);
 
   script.innerHTML = JSON.stringify({
     symbol: `NASDAQ:${ticker}`,
@@ -85,9 +62,10 @@ const renderSymbolInfo = (ticker) => {
     locale: "en",
     colorTheme: "light",
     isTransparent: false,
-  })
-   console.log(7);
-  container.appendChild(script);
-  console.log(8);
+  });
 
+  container.appendChild(script);
 };
+
+fetchNews("AAPL");
+renderSymbolInfo("AAPL");

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const handleTickerChange = (event) => {
   console.log(newTicker);
   fetchNews(newTicker);
   renderSymbolInfo(newTicker);
+  renderAdvancedChart(newTicker);
   }
 };
 
@@ -69,3 +70,50 @@ const renderSymbolInfo = (ticker) => {
 
 fetchNews("AAPL");
 renderSymbolInfo("AAPL");
+
+    //   <!-- TradingView Advanced Chart Widget BEGIN -->
+    //   <div class="tradingview-widget-container">
+    //     <div class="tradingview-widget-container__widget"></div>
+    //     <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js" async>
+    //     {
+    //       "width": "980",
+    //       "height": "100%",
+    //       "symbol": "NASDAQ:AAPL",
+    //       "interval": "60",
+    //       "timezone": "America/New_York",
+    //       "theme": "light",
+    //       "style": "1",
+    //       "locale": "en",
+    //       "hide_top_toolbar": true,
+    //       "allow_symbol_change": true,
+    //       "studies": ["STD;RSI"],
+    //       "support_host": "https://www.tradingview.com"
+    //     }
+    //     </script>
+    //   </div>
+    //   <!-- TradingView Advanced Chart Widget END -->
+    // </section>
+
+    const renderAdvancedChart = (ticker) => {
+      const container = document.getElementById("advanced-chart");
+      container.innerHTML = "";
+
+      const script = document.createElement("script");
+      script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js";
+      script.type = "text/javascript";
+      script.async = true;
+
+      script.innerHTML = JSON.stringify({
+        autosize: true,
+        symbol: `NASDAQ:${ticker}`,
+        interval: "D",
+        timezone: "America/New_York",
+        theme: "light",
+        style: "1",
+        locale: "en",
+        allow_symbol_change: true,
+      });
+
+      container.appendChild(script);
+    };
+  renderAdvancedChart("AAPL");

--- a/index.js
+++ b/index.js
@@ -1,17 +1,18 @@
 const apiKey = "d0vf12pr01qkepcvrurgd0vf12pr01qkepcvrus0";
-const ticker = "AAPL";
-const from = "2025-05-01";
-const to = "2025-06-03";
+// const ticker = "AAPL";
+// const from = "2025-05-01";
+// const to = "2025-06-03";
 
-fetch(`https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`)
-  .then(res => res.json())
-  .then(data => displayNews(data))
-  .catch(err => console.error(err));
+// fetch(`https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`)
+//   .then(res => res.json())
+//   .then(data => displayNews(data))
+//   .catch(err => console.error(err));
 
 // Create a news section
 const newsContainer = document.getElementById('news-articles');
 
 const displayNews = (articles) => {
+  newsContainer.innerHTML = "";
   const topTenArticles = articles.slice(0, 10);
   topTenArticles.forEach(article => {
     const p = document.createElement("p");
@@ -30,10 +31,25 @@ const displayNews = (articles) => {
 const searchInput = document.getElementById("stock-search");
 
 const handleTickerChange = (event) => {
-  if (event.key ==="Enter") {
+  if (event.key === "Enter") {
   const newTicker = event.target.value.toUpperCase();
   console.log(newTicker);
+  fetchNews(newTicker)
   }
 };
 
 searchInput.addEventListener("keydown", handleTickerChange);
+
+//Create Fetch News Function to fetch when a new stock is enetered
+
+const fetchNews = (ticker) => {
+  const from = "2025-05-01"
+  const to = "2025-06-03"
+  const url = `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`;
+  console.log(ticker);
+
+  fetch (url) 
+  .then(res => res.json())
+  .then(data => displayNews(data))
+  .catch(err => console.error(err));
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
-// Create a news section
-const newsContainer = document.getElementById('news-articles');
+const defaultTicker = "AAPL";
+const searchInput = document.getElementById("stock-search");
+
+const fetchNews = (ticker) => {
+  const from = "2025-05-01"
+  const to = "2025-06-03"
+  const url = `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`;
+   console.log("URL:", url);
+
+  fetch (url) 
+  .then(res => res.json())
+  .then(data => displayNews(data))
+  .catch(err => console.error(err));
+};
 
 const displayNews = (articles) => {
-  newsContainer.innerHTML = "";
+  const container  = document.getElementById('news-articles');
+  container.innerHTML = "";
+
   const topTenArticles = articles.slice(0, 10);
   topTenArticles.forEach(article => {
     const p = document.createElement("p");
@@ -13,13 +27,9 @@ const displayNews = (articles) => {
     link.target = "_blank";
 
     p.appendChild(link);
-    newsContainer.appendChild(p);
+    container.appendChild(p);
   });
-}
-
-//Grab Ticker from Stock-Search
-const searchInput = document.getElementById("stock-search");
-searchInput.innerHTML = "";
+};
 
 const handleTickerChange = (event) => {
   if (event.key === "Enter") {
@@ -32,23 +42,9 @@ const handleTickerChange = (event) => {
   renderFinancialData(newTicker);
   renderTechnicalAnalysis(newTicker);
   renderTopStories(newTicker);
-  }
-};
 
-searchInput.addEventListener("keydown", handleTickerChange);
-
-//Create Fetch News Function to fetch when a new stock is enetered
-
-const fetchNews = (ticker) => {
-  const from = "2025-05-01"
-  const to = "2025-06-03"
-  const url = `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`;
-   console.log("URL:", url);
-
-  fetch (url) 
-  .then(res => res.json())
-  .then(data => displayNews(data))
-  .catch(err => console.error(err));
+  searchInput.value = "";
+  };
 };
 
 const renderSymbolInfo = (ticker) => {
@@ -70,9 +66,6 @@ const renderSymbolInfo = (ticker) => {
 
   container.appendChild(script);
 };
-
-fetchNews("AAPL");
-renderSymbolInfo("AAPL");
 
 const renderAdvancedChart = (ticker) => {
   const container = document.getElementById("advanced-chart");
@@ -96,7 +89,6 @@ const renderAdvancedChart = (ticker) => {
 
   container.appendChild(script);
 };
-renderAdvancedChart("AAPL");
 
 const renderCompanyProfile = (ticker) => {
   const container = document.getElementById("company-profile");
@@ -118,7 +110,6 @@ const renderCompanyProfile = (ticker) => {
 
   container.appendChild(script);
 };
-renderCompanyProfile("AAPL");
 
 const renderFinancialData = (ticker) => {
   const container = document.getElementById("financial-data");
@@ -141,7 +132,6 @@ const renderFinancialData = (ticker) => {
 
   container.appendChild(script);
 };
-renderFinancialData("AAPL");
 
 const renderTechnicalAnalysis = (ticker) => {
   const container = document.getElementById("technical-analysis");
@@ -165,23 +155,6 @@ const renderTechnicalAnalysis = (ticker) => {
 
   container.appendChild(script);
 };
-renderTechnicalAnalysis("AAPL");
-
-      // <!-- TradingView Top Stories Widget BEGIN -->
-      // <div class="tradingview-widget-container">
-      //   <div class="tradingview-widget-container__widget"></div>
-      //   <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-timeline.js" async>
-      //   {
-      //     "feedMode": "all_symbols",
-      //     "width": "100%,
-      //     "height": "60%",
-      //     "colorTheme": "light",
-      //     "isTransparent": false,
-      //     "displayMode": "regular",
-      //     "locale": "en"
-      //   }
-      //   </script>
-      // </div>
 
 const renderTopStories = (ticker) => {
   const container = document.getElementById("top-stories");
@@ -204,4 +177,12 @@ const renderTopStories = (ticker) => {
 
   container.appendChild(script);
 };
-renderTopStories("AAPL");
+
+searchInput.addEventListener("keydown", handleTickerChange);
+fetchNews(defaultTicker);
+renderSymbolInfo(defaultTicker);
+renderAdvancedChart(defaultTicker);
+renderCompanyProfile(defaultTicker);
+renderFinancialData(defaultTicker);
+renderTechnicalAnalysis(defaultTicker);
+renderTopStories(defaultTicker);

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const handleTickerChange = (event) => {
   renderCompanyProfile(newTicker);
   renderFinancialData(newTicker);
   renderTechnicalAnalysis(newTicker);
+  renderTopStories(newTicker);
   }
 };
 
@@ -165,3 +166,42 @@ const renderTechnicalAnalysis = (ticker) => {
   container.appendChild(script);
 };
 renderTechnicalAnalysis("AAPL");
+
+      // <!-- TradingView Top Stories Widget BEGIN -->
+      // <div class="tradingview-widget-container">
+      //   <div class="tradingview-widget-container__widget"></div>
+      //   <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-timeline.js" async>
+      //   {
+      //     "feedMode": "all_symbols",
+      //     "width": "100%,
+      //     "height": "60%",
+      //     "colorTheme": "light",
+      //     "isTransparent": false,
+      //     "displayMode": "regular",
+      //     "locale": "en"
+      //   }
+      //   </script>
+      // </div>
+
+const renderTopStories = (ticker) => {
+  const container = document.getElementById("top-stories");
+  container.innerHTML = "";
+
+  const script = document.createElement("script");
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-timeline.js";
+  script.type = "text/javascript";
+  script.async = true;
+
+  script.innerHTML = JSON.stringify({
+    feedMode: "all_symbols",
+    width: "100%",
+    height: "60%",
+    colorTheme: "light",
+    isTransparent: false,
+    displayMode: "regular",
+    locale: "en"
+  });
+
+  container.appendChild(script);
+};
+renderTopStories("AAPL");

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const handleTickerChange = (event) => {
   renderSymbolInfo(newTicker);
   renderAdvancedChart(newTicker);
   renderCompanyProfile(newTicker);
+  renderFinancialData(newTicker);
   }
 };
 
@@ -37,7 +38,6 @@ searchInput.addEventListener("keydown", handleTickerChange);
 //Create Fetch News Function to fetch when a new stock is enetered
 
 const fetchNews = (ticker) => {
-  console.log("Fetching news for:", ticker);
   const from = "2025-05-01"
   const to = "2025-06-03"
   const url = `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${apiKey}`;
@@ -117,3 +117,26 @@ const renderCompanyProfile = (ticker) => {
   container.appendChild(script);
 };
 renderCompanyProfile("AAPL");
+
+const renderFinancialData = (ticker) => {
+  const container = document.getElementById("fundamental-data");
+  container.innerHTML = "";
+
+  const script = document.createElement("script");
+  script.src = "https://s3.tradingview.com/external-embedding/embed-widget-financials.js"
+  script.type = "text/javascript";
+  script.async = true;
+
+  script.innerHTML = JSON.stringify({
+    isTransparent: true,
+    displayMode: "adaptive",
+    width: 400,
+    height: 550,
+    colorTheme: "light",
+    symbol: `NASDAQ:${ticker}`,
+    locale: "en",
+  });
+
+  container.appendChild("script");
+};
+renderFinancialData("AAPL");


### PR DESCRIPTION
Implemented the search Bar Usage to change stock tickers:
 - Page loads initially with Apple stock info.
 - User can type a new stock ticker in the search-bar
 - Page will then display all Tradingview widgets and News from API for the new stock.


https://github.com/user-attachments/assets/add6d560-8227-4f98-bb50-7652c682cede

